### PR TITLE
Rename /career to /profilo

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,15 @@ import remarkGfm from 'remark-gfm'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+  async redirects() {
+    return [
+      {
+        source: '/career',
+        destination: '/profilo',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 const withMDX = nextMDX({

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -188,10 +188,10 @@ function Resume() {
       </ol>
       <div className="mt-6">
         <Link
-          href="/career"
+          href="/profilo"
           className="inline-flex items-center gap-2 text-sm font-medium text-teal-600 hover:text-teal-700 dark:text-teal-300 dark:hover:text-teal-200"
         >
-          View full career
+          View full profilo
           <ArrowDownIcon className="h-4 w-4 rotate-[-135deg]" />
         </Link>
       </div>

--- a/src/app/profilo/page.jsx
+++ b/src/app/profilo/page.jsx
@@ -82,7 +82,7 @@ export const metadata = {
   }
 }
 
-export default function career() {
+export default function Profilo() {
   return (
     <SimpleLayout
       title="Building the Future: My Experience in Tech"

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -40,7 +40,7 @@ export default function sitemap() {
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/career`,
+      url: `${baseUrl}/profilo`,
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.8,

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -22,7 +22,7 @@ export function Footer() {
             <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
               <div className="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-800 dark:text-zinc-200">
                 <NavLink href="/about">About</NavLink>
-                <NavLink href="/career">Career</NavLink>
+                <NavLink href="/profilo">Profilo</NavLink>
                 <NavLink href="/travel">TraveledMap</NavLink>
               </div>
               <p className="text-sm text-zinc-600 dark:text-zinc-300">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -131,7 +131,7 @@ function MobileNavigation(props) {
               <ul className="-my-2 divide-y divide-zinc-100 text-base text-zinc-800 dark:divide-zinc-100/5 dark:text-zinc-300">
                 <MobileNavItem href="/about">About</MobileNavItem>
                 <MobileNavItem href="/tech-stack">TechStack</MobileNavItem>
-                <MobileNavItem href="/career">Career</MobileNavItem>
+                <MobileNavItem href="/profilo">Profilo</MobileNavItem>
                 <MobileNavItem href="/travel">TraveledMap</MobileNavItem>
               </ul>
             </nav>
@@ -171,7 +171,7 @@ function DesktopNavigation(props) {
       <ul className="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10">
         <NavItem href="/about">About</NavItem>
         <NavItem href="/tech-stack">TechStack</NavItem>
-        <NavItem href="/career">Career</NavItem>
+        <NavItem href="/profilo">Profilo</NavItem>
         <NavItem href="/travel">TraveledMap</NavItem>
       </ul>
     </nav>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renames the career portfolio route to `/profilo` and adds a permanent redirect so existing `/career` links keep working.

## Changes

- Moved `src/app/career/` → `src/app/profilo/`
- Updated navigation links in Header and Footer
- Updated homepage "View full profilo" link
- Updated sitemap entry
- Added 301 redirect: `/career` → `/profilo`

## Footer note

The footer copyright year is already dynamic via `new Date().getFullYear()` — no change was needed there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1765c643-6fe9-4142-bfff-ac2d7e88923b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1765c643-6fe9-4142-bfff-ac2d7e88923b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

